### PR TITLE
Upgrade egui library version to 0.24.1 to fix epaint conflicts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["egui", "nerdfonts", "icons", "symbols", "font"]
 categories = ["gui"]
 
 [dependencies]
-egui = { version = "0.22", default-features = false }
+egui = { version = "0.24.1", default-features = false }
 
 [dev-dependencies]
 eframe = "0.22"


### PR DESCRIPTION
Upgrading egui library to 0.24.1 to fix epaint conflicts