### PR TITLE
Upgrading egui library to 0.27.2 to fix epaint conflicts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "egui_nerdfonts"
 description = "Nerdfonts icons for egui"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/bernsteining/egui_nerdfonts"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ keywords = ["egui", "nerdfonts", "icons", "symbols", "font"]
 categories = ["gui"]
 
 [dependencies]
-egui = { version = "0.24.1", default-features = false }
+egui = { version = "0.27.2", default-features = false }
 
 [dev-dependencies]
-eframe = "0.24.1"
+eframe = "0.27"
 
 [[example]]
 name = "rust_logo"


### PR DESCRIPTION
Upgrading egui library to 0.27.2 to fix epaint conflicts